### PR TITLE
Add reload action and ability to stop an active resource

### DIFF
--- a/pgsqlsr
+++ b/pgsqlsr
@@ -235,7 +235,8 @@ is_startable() {
     # Going back from master to slave automaticaly is dangerous.
     # Avoid any further failover until a human being unblocks the resource.
     # Also, the old master should not be started again.
-    return test -z "$OCF_RESKEY_startable" -o "$OCF_RESKEY_startable" = "$(uname -n)"
+    test -z "$OCF_RESKEY_startable" -o "$OCF_RESKEY_startable" = "$(uname -n)"
+    return $?
 }
 
 # Promote a slave server to master (from the PostgreSQL point of

--- a/pgsqlsr
+++ b/pgsqlsr
@@ -15,12 +15,10 @@
 OCF_RESKEY_system_user_default=postgres
 OCF_RESKEY_bindir_default=/usr/bin
 OCF_RESKEY_pgdata_default=/var/lib/pgsql/data
-OCF_RESKEY_startable_default=all
 
 : ${OCF_RESKEY_system_user=${OCF_RESKEY_system_user_default}}
 : ${OCF_RESKEY_bindir=${OCF_RESKEY_bindir_default}}
 : ${OCF_RESKEY_pgdata=${OCF_RESKEY_pgdata_default}}
-: ${OCF_RESKEY_startable=${OCF_RESKEY_startable_default}}
 
 
 function pgsql_validate_all() {
@@ -69,12 +67,12 @@ ocf_meta_data() {
   </longdesc>
   <shortdesc lang="en">Manages PostgreSQL servers in replication</shortdesc>
   <parameters>
-    <parameter name="startable" unique="0" required="1">
+    <parameter name="startable" unique="0" required="0">
       <longdesc lang="en">
-        On which nodes is the resource startable ?
-        Possible values:
-          "all" for all nodes ;
-          "hostname" for only one node (used in case of failover, to avoid failback).
+        Values for this parameter show which nodes the resource is startable on.
+        If not set, all nodes are allowed to run the resource.
+        When set to an hostname, it only allows this one node.
+        This is automatically done in case of failover, to avoid failback.
       </longdesc>
       <shortdesc lang="en">Nodes allowed to start the resource</shortdesc>
       <content type="string" default="" />
@@ -179,6 +177,9 @@ pg_start() {
 }
 
 pg_reload() {
+    # no action necessary, this action is just to inform pacemaker that
+    # modification of non-unique parameters can be applied without 
+    # restarting the resource
     ocf_log info "startable attribute changed to: $OCF_RESKEY_startable"
     return $OCF_SUCCESS
 }
@@ -226,7 +227,7 @@ case $1 in
 
         # on a master, just start pgsql.
         # start is a promotion on a slave
-        if [ "$OCF_RESKEY_startable" != "all" ] && [ "$(uname -n)" != "$OCF_RESKEY_startable" ]; then
+        if [ "$OCF_RESKEY_startable" != "" ] && [ "$(uname -n)" != "$OCF_RESKEY_startable" ]; then
             # Avoid any further failover until a human being unblocks the resource
             ocf_log err "Resource is blocked. A failover has occured on '${OCF_RESKEY_startable}'."
             exit $OCF_ERR_GENERIC

--- a/pgsqlsr
+++ b/pgsqlsr
@@ -36,13 +36,13 @@ function pgsql_validate_all() {
 
     # check pgdata
     if [ ! -d "${OCF_RESKEY_pgdata}" ] ; then
-        ocf_log err "PGDATA \"${OCF_RESKEY_pgdata}\" doesn't exist";
+        ocf_log error "PGDATA \"${OCF_RESKEY_pgdata}\" doesn't exist";
         return $OCF_ERR_CONFIGURED
     fi
 
     # check pgdata
     if [ ! -s "${OCF_RESKEY_pgdata}/PG_VERSION" ] ; then
-        ocf_log err "PG_VERSION does not exists in \"${OCF_RESKEY_pgdata}\"";
+        ocf_log error "PG_VERSION does not exists in \"${OCF_RESKEY_pgdata}\"";
         return $OCF_ERR_CONFIGURED
     fi
 
@@ -50,7 +50,7 @@ function pgsql_validate_all() {
     id -nu "${OCF_RESKEY_system_user}" > /dev/null 2>&1
     rc=$?
     if [ ! $rc ] ; then
-        ocf_log err "System user \"${OCF_RESKEY_system_user}\" doesn't exist";
+        ocf_log error "System user \"${OCF_RESKEY_system_user}\" doesn't exist";
         return $OCF_ERR_CONFIGURED
     fi
 }
@@ -136,29 +136,59 @@ EOF
 # file.
 #
 pg_is_master() {
-    su -l -c "${OCF_RESKEY_bindir}/pg_controldata ${OCF_RESKEY_pgdata} | grep -Eq '^Database cluster state: +in production'" ${OCF_RESKEY_system_user}
-    return $?
+    local instance_state
+    local rc
+
+    instance_state=$(su -l -c "${OCF_RESKEY_bindir}/pg_controldata ${OCF_RESKEY_pgdata} | \
+        grep -E '^Database cluster state: +' | \
+        sed 's/^Database cluster state: \+//'" \
+        ${OCF_RESKEY_system_user})
+
+    case $instance_state in
+        "in production"|"shut down")
+            # Master state
+            ocf_log debug "$__OCF_ACTION - pg_is_master : instance $OCF_RESOURCE_INSTANCE is Primary."
+            ocf_log debug "$__OCF_ACTION - pg_is_master : instance $OCF_RESOURCE_INSTANCE state is \"$instance_state\"."
+            rc=$OCF_SUCCESS
+            ;;
+        "in archive recovery"|"shut down in recovery")
+            # Slave state
+            ocf_log debug "$__OCF_ACTION - pg_is_master : instance $OCF_RESOURCE_INSTANCE is Standby."
+            ocf_log debug "$__OCF_ACTION - pg_is_master : instance $OCF_RESOURCE_INSTANCE state is \"$instance_state\"."
+            rc=$OCF_ERR_GENERIC
+            ;;
+        *)
+            # crash recovery or shutting down
+            ocf_log error "$__OCF_ACTION - pg_is_master : unable find out if $OCF_RESOURCE_INSTANCE is Primary or Standby."
+            ocf_log debug "$__OCF_ACTION - pg_is_master : instance state is \"$instance_state\"."
+            exit $OCF_ERR_GENERIC
+            ;;
+         esac
+
+    return $rc
 }
 
 # Find if a server is running. We use pg_ctl to test if the
 # postmaster.pid is correct.
 #
 # returns $OCF_NOT_RUNNING when stopped, $OCF_SUCCESS when started
-pg_status() {
+pg_is_running() {
     local rc
-    local is_master
 
     su -l -c "${OCF_RESKEY_bindir}/pg_ctl -D ${OCF_RESKEY_pgdata} status 2>/dev/null|grep -q 'server is running'" ${OCF_RESKEY_system_user}
     rc=$?
 
     # check whether PostgreSQL is running or not
     if [ $rc -eq 0 ]; then
+        ocf_log debug "$__OCF_ACTION - pg_is_running : instance $OCF_RESOURCE_INSTANCE is running."
         return $OCF_SUCCESS
     elif [ $rc -eq 1 ]; then
+        ocf_log debug "$__OCF_ACTION - pg_is_running : instance $OCF_RESOURCE_INSTANCE is not running."
         return $OCF_NOT_RUNNING
     fi
 
     # PostgreSQL state is unknown
+    ocf_log error "$__OCF_ACTION - pg_is_running : status of instance $OCF_RESOURCE_INSTANCE is unknown."
     return $OCF_ERR_GENERIC
 }
 
@@ -170,9 +200,27 @@ pg_start() {
     rc=$?
 
     if test $rc -eq 0; then
+        ocf_log info "$__OCF_ACTION - pg_start : instance $OCF_RESOURCE_INSTANCE started."
         return $OCF_SUCCESS
     fi
 
+    ocf_log error "$__OCF_ACTION - pg_start : instance $OCF_RESOURCE_INSTANCE failed to start."
+    return $OCF_ERR_GENERIC
+}
+
+# Stop the PostgreSQL server
+pg_stop() {
+    local rc
+
+    su -l -c "${OCF_RESKEY_bindir}/pg_ctl -D ${OCF_RESKEY_pgdata} -m fast -w stop" ${OCF_RESKEY_system_user}
+    rc=$?
+
+    if test $rc -eq 0; then
+        ocf_log info "$__OCF_ACTION - pg_stop : instance $OCF_RESOURCE_INSTANCE stopped."
+        return $OCF_SUCCESS
+    fi
+
+    ocf_log error "$__OCF_ACTION - pg_stop : instance $OCF_RESOURCE_INSTANCE failed to stop."
     return $OCF_ERR_GENERIC
 }
 
@@ -180,7 +228,17 @@ pg_reload() {
     # no action necessary, this action is just to inform pacemaker that
     # modification of non-unique parameters can be applied without 
     # restarting the resource
-    ocf_log info "startable attribute changed to: $OCF_RESKEY_startable"
+    ocf_log info "$__OCF_ACTION - pg_reload : instance $OCF_RESOURCE_INSTANCE \"startable\" attribute changed to: \"$OCF_RESKEY_startable\"."
+    return $OCF_SUCCESS
+}
+
+is_startable() {
+    # Going back from master to slave automaticaly is dangerous.
+    # Avoid any further failover until a human being unblocks the resource.
+    # Also, the old master should not be started again.
+    if [ "$OCF_RESKEY_startable" != "" ] && [ "$(uname -n)" != "$OCF_RESKEY_startable" ]; then
+        return $OCF_ERR_GENERIC
+    fi
     return $OCF_SUCCESS
 }
 
@@ -205,9 +263,11 @@ failover() {
         do
             sleep 1
         done
+        ocf_log info "$__OCF_ACTION - failover : instance $OCF_RESOURCE_INSTANCE promoted."
         return $OCF_SUCCESS
     fi
 
+    ocf_log error "$__OCF_ACTION - failover : failed to promote instance ${OCF_RESOURCE_INSTANCE}."
     return $OCF_ERR_GENERIC
 }
 
@@ -225,52 +285,55 @@ case $1 in
     start)
         pgsql_validate_all || exit $?
 
-        # on a master, just start pgsql.
-        # start is a promotion on a slave
-        if [ "$OCF_RESKEY_startable" != "" ] && [ "$(uname -n)" != "$OCF_RESKEY_startable" ]; then
+        # do not attempt to start on another node if startable is set
+        if ! is_startable; then
+            # Going back from master to slave automaticaly is dangerous
             # Avoid any further failover until a human being unblocks the resource
-            ocf_log err "Resource is blocked. A failover has occured on '${OCF_RESKEY_startable}'."
+            ocf_log error "$__OCF_ACTION - Resource is blocked. A failover has occured on \"${OCF_RESKEY_startable}\"."
+            ocf_log info "Going back from Primary to Standby forbidden. Rebuild the standby server."
             exit $OCF_ERR_GENERIC
         fi
 
+        # on a master, just start pgsql.
+        # start is a promotion on a slave
         if pg_is_master ; then
             # Master
-            pg_status
+            pg_is_running
             rc=$?
 
             case $rc in
             $OCF_SUCCESS)
-                ocf_log info "Primary server already started"
+                ocf_log info "$__OCF_ACTION - Primary $OCF_RESOURCE_INSTANCE already started."
                 exit $OCF_SUCCESS
                 ;;
             $OCF_NOT_RUNNING)
-                ocf_log info "Starting Primary server"
+                ocf_log info "$__OCF_ACTION - Starting Primary ${OCF_RESOURCE_INSTANCE}."
                 pg_start
                 exit $?
                 ;;
             $OCF_ERR_GENERIC)
-                ocf_log error "Undefined status on the Primary server"
+                ocf_log error "$__OCF_ACTION - Undefined status on the Primary ${OCF_RESOURCE_INSTANCE}."
                 exit $OCF_ERR_GENERIC
                 ;;
             esac
         else
             # Slave
-            pg_status
+            pg_is_running
             rc=$?
 
             case $rc in
             # if not running, we try to start the slave, then promote it.
             $OCF_NOT_RUNNING)
-                ocf_log info "Starting Standby server"
+                ocf_log info "$__OCF_ACTION - Starting Standby ${OCF_RESOURCE_INSTANCE}."
                 pg_start
                 ;&
             $OCF_SUCCESS)
-                ocf_log info "Promoting Standby server to Master"
+                ocf_log info "$__OCF_ACTION - Promoting Standby ${OCF_RESOURCE_INSTANCE} server to Primary."
                 failover
                 exit $?
                 ;;
             $OCF_ERR_GENERIC)
-                ocf_log error "Undefined status on the Standby server"
+                ocf_log error "$__OCF_ACTION - Undefined status on the Standby ${OCF_RESOURCE_INSTANCE}."
                 exit $OCF_ERR_GENERIC
                 ;;
             esac
@@ -279,9 +342,33 @@ case $1 in
     stop)
         pgsql_validate_all || exit $?
 
-        # Going back from master to slave automaticaly is dangerous
-        ocf_log info "Going back from Primary to Standby forbidden. Rebuild the standby server"
-        exit $OCF_SUCCESS
+        # On a master, just stop the instance.
+        # Stop is ignored on a slave.
+        if pg_is_master ; then
+            # Master
+            pg_is_running
+            rc=$?
+
+            case $rc in
+            $OCF_SUCCESS)
+                ocf_log info "$__OCF_ACTION - Stopping Primary ${OCF_RESOURCE_INSTANCE}."
+                pg_stop
+                exit $?
+                ;;
+            $OCF_NOT_RUNNING)
+                ocf_log info "$__OCF_ACTION - Primary ${OCF_RESOURCE_INSTANCE} is not running."
+                exit $OCF_SUCCESS
+                ;;
+            $OCF_ERR_GENERIC)
+                ocf_log error "$__OCF_ACTION - Undefined status on the Primary ${OCF_RESOURCE_INSTANCE}."
+                exit $OCF_ERR_GENERIC
+                ;;
+            esac
+        else
+            # Slave
+            ocf_log_info "$__OCF_ACTION - No need to stop a Standby."
+            exit $OCF_SUCCESS
+        fi
         ;;
     reload)
         pg_reload
@@ -290,34 +377,40 @@ case $1 in
     monitor)
         pgsql_validate_all || exit $?
 
-        # return the status of each node
+        # Return the status of each node.
         # As we are in a standalone service from the CRM point of view
         # master should return it is started (rc=$OCF_SUCCESS) and slave
         # it is stopped (rc=$OCF_NOT_RUNNING)
         if pg_is_master; then
             # Master
 
-            pg_status
+            pg_is_running
             rc=$?
 
-            case $rc in
-            $OCF_SUCCESS)
+            if [ $rc -eq $OCF_SUCCESS ] && is_startable; then
+                # Master is started and allowed to run.
                 ocf_log debug "Monitor successful on Primary"
                 exit $OCF_SUCCESS
-                ;;
-            *)
-                ocf_log err "Undefined state"
+            elif [ $rc -eq $OCF_SUCCESS ] && ! is_startable; then
+                # A Master is started on a not allowed node.
+                # Stop it.
+                ocf_log error "$__OCF_ACTION - Resource is blocked. A failover has occured on \"${OCF_RESKEY_startable}\"."
+                ocf_log info "The instance ${OCF_RESOURCE_INSTANCE} should not run as a Primary on this node."
+                pg_stop
                 exit $OCF_ERR_GENERIC
-                ;;
-            esac
+            else
+                # The instance is stopped 
+                ocf_log error "$__OCF_ACTION - The instance ${OCF_RESOURCE_INSTANCE} is not running."
+                exit $OCF_NOT_RUNNING
+            fi
         else
             # Slave
-            pg_status
+            pg_is_running
             rc=$?
 
             case $rc in
             $OCF_NOT_RUNNING)
-                ocf_log info "Starting the Standby"
+                ocf_log info "$__OCF_ACTION - Starting the Standby ${OCF_RESOURCE_INSTANCE}."
                 pg_start
                 ;&
             $OCF_SUCCESS)
@@ -325,7 +418,7 @@ case $1 in
                 exit $OCF_NOT_RUNNING
                 ;;
             $OCF_ERR_GENERIC)
-                ocf_log err "Undefined state"
+                ocf_log error "$__OCF_ACTION - Undefined state for instance ${OCF_RESOURCE_INSTANCE}."
                 exit $OCF_ERR_GENERIC
                 ;;
             esac

--- a/pgsqlsr
+++ b/pgsqlsr
@@ -139,7 +139,7 @@ pg_is_master() {
     local instance_state
     local rc
 
-    instance_state=$(su -l -c "${OCF_RESKEY_bindir}/pg_controldata ${OCF_RESKEY_pgdata} | \
+    instance_state=$(su -l -c "LANG=C ${OCF_RESKEY_bindir}/pg_controldata ${OCF_RESKEY_pgdata} | \
         sed -rn 's/^Database cluster state:\s+(.*)/\1/p'" \
         ${OCF_RESKEY_system_user})
 
@@ -174,7 +174,7 @@ pg_is_master() {
 pg_is_running() {
     local rc
 
-    su -l -c "${OCF_RESKEY_bindir}/pg_ctl -D ${OCF_RESKEY_pgdata} status 2>/dev/null|grep -q 'server is running'" ${OCF_RESKEY_system_user}
+    su -l -c "LANG=C ${OCF_RESKEY_bindir}/pg_ctl -D ${OCF_RESKEY_pgdata} status 2>/dev/null|grep -q 'server is running'" ${OCF_RESKEY_system_user}
     rc=$?
 
     # check whether PostgreSQL is running or not

--- a/pgsqlsr
+++ b/pgsqlsr
@@ -15,10 +15,12 @@
 OCF_RESKEY_system_user_default=postgres
 OCF_RESKEY_bindir_default=/usr/bin
 OCF_RESKEY_pgdata_default=/var/lib/pgsql/data
+OCF_RESKEY_startable_default=all
 
 : ${OCF_RESKEY_system_user=${OCF_RESKEY_system_user_default}}
 : ${OCF_RESKEY_bindir=${OCF_RESKEY_bindir_default}}
 : ${OCF_RESKEY_pgdata=${OCF_RESKEY_pgdata_default}}
+: ${OCF_RESKEY_startable=${OCF_RESKEY_startable_default}}
 
 
 function pgsql_validate_all() {
@@ -67,11 +69,14 @@ ocf_meta_data() {
   </longdesc>
   <shortdesc lang="en">Manages PostgreSQL servers in replication</shortdesc>
   <parameters>
-    <parameter name="startable" unique="0" required="0">
+    <parameter name="startable" unique="0" required="1">
       <longdesc lang="en">
-        Is the resource startable ?
+        On which nodes is the resource startable ?
+        Possible values:
+          "all" for all nodes ;
+          "hostname" for only one node (used in case of failover, to avoid failback).
       </longdesc>
-      <shortdesc lang="en">Is the resource startable ?</shortdesc>
+      <shortdesc lang="en">Nodes allowed to start the resource</shortdesc>
       <content type="string" default="" />
     </parameter>
 
@@ -91,7 +96,7 @@ ocf_meta_data() {
       <content type="string" default="${OCF_RESKEY_bindir_default}" />
     </parameter>
 
-    <parameter name="pgdata" unique="0" required="0">
+    <parameter name="pgdata" unique="1" required="0">
       <longdesc lang="en">
         Path to the data directory, e.g. PGDATA
       </longdesc>
@@ -104,6 +109,7 @@ ocf_meta_data() {
     <action name="start" timeout="120" />
     <action name="stop" timeout="120" />
     <action name="status" timeout="60" />
+    <action name="reload" timeout="120" />
     <action name="monitor" depth="0" timeout="30" interval="30"/>
     <action name="meta-data" timeout="5" />
     <action name="validate-all" timeout="5" />
@@ -118,6 +124,7 @@ ocf_methods() {
         start
         stop
         status
+        reload
         monitor
         methods
         meta-data
@@ -135,7 +142,7 @@ pg_is_master() {
     return $?
 }
 
-# Find if a server is running. We use pg_ctl to test is the
+# Find if a server is running. We use pg_ctl to test if the
 # postmaster.pid is correct.
 #
 # returns $OCF_NOT_RUNNING when stopped, $OCF_SUCCESS when started
@@ -146,14 +153,14 @@ pg_status() {
     su -l -c "${OCF_RESKEY_bindir}/pg_ctl -D ${OCF_RESKEY_pgdata} status 2>/dev/null|grep -q 'server is running'" ${OCF_RESKEY_system_user}
     rc=$?
 
-    # le noeud n'est pas démarré
+    # check whether PostgreSQL is running or not
     if [ $rc -eq 0 ]; then
         return $OCF_SUCCESS
     elif [ $rc -eq 1 ]; then
         return $OCF_NOT_RUNNING
     fi
 
-    # sinon erreur
+    # PostgreSQL state is unknown
     return $OCF_ERR_GENERIC
 }
 
@@ -169,6 +176,11 @@ pg_start() {
     fi
 
     return $OCF_ERR_GENERIC
+}
+
+pg_reload() {
+    ocf_log info "startable attribute changed to: $OCF_RESKEY_startable"
+    return $OCF_SUCCESS
 }
 
 # Promote a slave server to master (from the PostgreSQL point of
@@ -214,10 +226,9 @@ case $1 in
 
         # on a master, just start pgsql.
         # start is a promotion on a slave
-        startable="$(crm_resource --resource $OCF_RESOURCE_INSTANCE --get-parameter startable)"
-        if [ "$startable" != "" ] && [ "$(uname -n)" != "$startable" ]; then
+        if [ "$OCF_RESKEY_startable" != "all" ] && [ "$(uname -n)" != "$OCF_RESKEY_startable" ]; then
             # Avoid any further failover until a human being unblocks the resource
-            ocf_log err "Resource is blocked. A failover has occured on '${startable}'."
+            ocf_log err "Resource is blocked. A failover has occured on '${OCF_RESKEY_startable}'."
             exit $OCF_ERR_GENERIC
         fi
 
@@ -242,7 +253,7 @@ case $1 in
                 ;;
             esac
         else
-            # cas de l'esclave
+            # Slave
             pg_status
             rc=$?
 
@@ -271,6 +282,10 @@ case $1 in
         ocf_log info "Going back from Primary to Standby forbidden. Rebuild the standby server"
         exit $OCF_SUCCESS
         ;;
+    reload)
+        pg_reload
+        exit $?
+        ;;
     monitor)
         pgsql_validate_all || exit $?
 
@@ -279,14 +294,14 @@ case $1 in
         # master should return it is started (rc=$OCF_SUCCESS) and slave
         # it is stopped (rc=$OCF_NOT_RUNNING)
         if pg_is_master; then
-            # cas du maitre
+            # Master
 
             pg_status
             rc=$?
 
             case $rc in
             $OCF_SUCCESS)
-                ocf_log debug "Monitor succesful on Primary"
+                ocf_log debug "Monitor successful on Primary"
                 exit $OCF_SUCCESS
                 ;;
             *)
@@ -295,7 +310,7 @@ case $1 in
                 ;;
             esac
         else
-            # cas de l'esclave
+            # Slave
             pg_status
             rc=$?
 

--- a/pgsqlsr
+++ b/pgsqlsr
@@ -140,8 +140,7 @@ pg_is_master() {
     local rc
 
     instance_state=$(su -l -c "${OCF_RESKEY_bindir}/pg_controldata ${OCF_RESKEY_pgdata} | \
-        grep -E '^Database cluster state: +' | \
-        sed 's/^Database cluster state: \+//'" \
+        sed -rn 's/^Database cluster state:\s+(.*)/\1/p'" \
         ${OCF_RESKEY_system_user})
 
     case $instance_state in
@@ -236,10 +235,7 @@ is_startable() {
     # Going back from master to slave automaticaly is dangerous.
     # Avoid any further failover until a human being unblocks the resource.
     # Also, the old master should not be started again.
-    if [ "$OCF_RESKEY_startable" != "" ] && [ "$(uname -n)" != "$OCF_RESKEY_startable" ]; then
-        return $OCF_ERR_GENERIC
-    fi
-    return $OCF_SUCCESS
+    return test -z "$OCF_RESKEY_startable" -o "$OCF_RESKEY_startable" = "$(uname -n)"
 }
 
 # Promote a slave server to master (from the PostgreSQL point of


### PR DESCRIPTION
Also, several other modifications : 
- adding shutdown states detection in pg_is_master function ;
- function pg_status renamed to pg_is_running to reflect what it really does ;
- modification of monitor action so that it can detect if a Primary is started on a node it should not run on due to the startable parameter ;
- make pg_ctl and pg_controldata independant of locale settings ;
- info and debug messages added.
